### PR TITLE
Fix links to external sites

### DIFF
--- a/_posts/2011-03-21-importer-et-classer-automatiquement-ses-photos-numeriques.md
+++ b/_posts/2011-03-21-importer-et-classer-automatiquement-ses-photos-numeriques.md
@@ -62,4 +62,4 @@ exiftool -ext JPG -ext AVI "-Directory<DateTimeOriginal" -d "%Y-%m-%d" .
 ```
 
 Le script est disponible sur mon
-[GitHub](https://github.com/YannMoisan/dotfiles/blob/master/scripts/photo-import).
+[GitHub](https://github.com/YannMoisan/dotfiles/blob/master/bin/photo-import).

--- a/_posts/2011-09-21-librairie-mathematiques.md
+++ b/_posts/2011-09-21-librairie-mathematiques.md
@@ -17,9 +17,9 @@ Je choisis évidemment Java pour l'implémentation. Malheureusement, le JDK offr
 les mathématiques. En effet, il n'y a que la classe Math, les types primitifs et les wrappers :
 Integer, Long, BigInteger, … Cependant, il existe plusieurs librairies, en voici quelques unes :
 
--   [Google guava](http://code.google.com/p/guava-libraries/)
+-   [Google guava](https://github.com/google/guava)
 -   [Apache math](http://commons.apache.org/math/)
--   [Colt](http://acs.lbl.gov/software/colt/index.htm)
+-   [Colt](https://dst.lbl.gov/ACSSoftware/colt/)
 
 ## Ma librairie
 

--- a/_posts/2012-05-01-evolution-de-java.md
+++ b/_posts/2012-05-01-evolution-de-java.md
@@ -34,7 +34,7 @@ aujourd'hui.
 
 ## Avec Guava
 
-[Guava](http://code.google.com/p/guava-libraries/) est une librairie développée par Google qui offre
+[Guava](https://github.com/google/guava) est une librairie développée par Google qui offre
 notamment une API Collection riche et un support partiel de la programmation fonctionnelle. Cette
 librairie remplace avantageusement la librairie commons collections d'Apache, tombé en désuétude.
 
@@ -92,8 +92,8 @@ départ dans ce but.
 ## Avec Java 8
 
 [Java 8](http://openjdk.java.net/projects/jdk8/) apportera le support très attendu des
-[lambda-expressions](http://openjdk.java.net/projects/lambda/) (JSR 335). Une version [binary
-snapshot](http://jdk8.java.net/lambda/) permet d'essayer ces nouveautés.
+[lambda-expressions](http://openjdk.java.net/projects/lambda/) (JSR 335). Une version binary
+snapshot permet d'essayer ces nouveautés.
 
 ```
 import java.util.ArrayList;
@@ -138,6 +138,3 @@ Iterable<T> filter(Predicate<? super T> predicate) default {
 Le code est beaucoup plus lisible qu'avec Guava, ce qui démontre la nécessité de mettre à jour le
 langage car les librairies tierces ne permettent pas d'obtenir le même résultat. De plus, la méthode
 `reduce` est supportée alors que Guava ne la supporte pas.
-
-Référence : Les slides de Brian Goetz à Devoxx :
-[devoxx-lang-lib-vm-co-evol.pdf](http://blogs.oracle.com/briangoetz/resource/devoxx-lang-lib-vm-co-evol.pdf)

--- a/_posts/2012-05-18-jersey-vs-spring-mvc.md
+++ b/_posts/2012-05-18-jersey-vs-spring-mvc.md
@@ -198,13 +198,8 @@ Ma préférence va à Jersey car il est simple, standard et testable.
 
 ## Ressources externes
 
--   [Le code source du billet](https://github.com/YannMoisan/restcmp)
--   
-
-    1: [Learn REST: A Tutorial](http://rest.elkstein.org/)
--   
-
-    2: ~~Supporting XML and JSON web service endpoints in Spring 3.1 using @ResponseBody~~
--   3: [REST with Java (JAX-RS) using Jersey](http://www.vogella.com/articles/REST/article.html)
--   4: [A Comparison of Spring MVC and JAX-RS](http://www.infoq.com/articles/springmvc_jsx-rs)
-
+<p><a href="https://github.com/YannMoisan/restcmp">Le code source du billet</a></p>
+<p id="note1">[1] <a href="http://rest.elkstein.org/">Learn REST: A Tutorial</a></p>
+<p id="note2">[2] <del>Supporting XML and JSON web service endpoints in Spring 3.1 using @ResponseBody</del></p>
+<p><a href="http://www.vogella.com/articles/REST/article.html">REST with Java (JAX-RS) using Jersey</a></p>
+<p><a href="http://www.infoq.com/articles/springmvc_jsx-rs">A Comparison of Spring MVC and JAX-RS</a></p>

--- a/_posts/2012-05-18-jersey-vs-spring-mvc.md
+++ b/_posts/2012-05-18-jersey-vs-spring-mvc.md
@@ -151,7 +151,7 @@ public class FibResourceTest extends JerseyTest {
 ```
 
 Pour Spring, il faut utiliser un autre projet :
-[spring-test-mvc](https://github.com/SpringSource/spring-test-mvc) qui a vocation à être intégré au
+`spring-test-mvc` qui a vocation à être intégré au
 module spring-test de Spring Framework. Ce projet se base sur l'utilisation de Mock et permet de
 tester sans conteneur de Servlet. Pour récupérer la dépendance avec Maven, il faut ajouter le
 repository maven snapshot de Spring.
@@ -204,8 +204,7 @@ Ma préférence va à Jersey car il est simple, standard et testable.
     1: [Learn REST: A Tutorial](http://rest.elkstein.org/)
 -   
 
-    2: [Supporting XML and JSON web service endpoints in Spring 3.1 using
-    @ResponseBody](http://springinpractice.com/2012/02/22/supporting-xml-and-json-web-service-endpoints-in-spring-3-1-using-responsebody/)
+    2: ~~Supporting XML and JSON web service endpoints in Spring 3.1 using @ResponseBody~~
 -   3: [REST with Java (JAX-RS) using Jersey](http://www.vogella.com/articles/REST/article.html)
 -   4: [A Comparison of Spring MVC and JAX-RS](http://www.infoq.com/articles/springmvc_jsx-rs)
 

--- a/_posts/2012-06-06-dojo-scala.md
+++ b/_posts/2012-06-06-dojo-scala.md
@@ -27,8 +27,7 @@ tout un tas de méthodes utilitaires : `equals`, `hashCode`, `toString`.
 
 Après la pause pizza, des groupes plus informels se forment pour discuter. Une personne (désolé,
 étant nouveau, je ne connais pas les prénoms) fait suite à ma demande et me montre comment faire
-cohabiter Java et Scala dans Eclipse et me donne quelques infos sur le
-[maven-scala-plugin](http://scala-tools.org/mvnsites/maven-scala-plugin/). On echange alors sur les
+cohabiter Java et Scala dans Eclipse et me donne quelques infos sur le `maven-scala-plugin`. On echange alors sur les
 pratiques de test et il m'indique l'existence d'un plugin eclipse pour ScalaTest et du projet
 [specs2](http://etorreborre.github.com/specs2/) plus orienté BDD.
 

--- a/_posts/2012-08-01-java-7.md
+++ b/_posts/2012-08-01-java-7.md
@@ -22,14 +22,13 @@ Voici celles que j'utilise et que trouve très pratiques :
     operator](http://docs.oracle.com/javase/7/docs/technotes/guides/language/type-inference-generic-instance-creation.html)
     qui permet d'omettre la déclaration des types génériques, le compilateur réalisant de
     l'inférence de type.
--   [java.nio.file.Path](http://openjdk.java.net/projects/nio/javadoc/java/nio/file/Path.html) qui
-    remplace avantageusement la classe File en offrant une API plus riche.
+-   `java.nio.file.Path` qui remplace avantageusement la classe File en offrant une API plus riche.
 -   [java.util.Objects](http://docs.oracle.com/javase/7/docs/api/java/util/Objects.html) qui est une
     classe utilitaire (étonnament ressemblante avec la classe `Objects` de guava) fournissant des
     méthodes de base pour travailler avec des `Object` : `equals`, `hashCode`, `toString`. A noter,
     Eclipse 3.7 ne tire pas partie de ces méthodes lors de la génération des méthodes `equals` et
     `hashCode`.
-
+    
 ## Une incompatibilité avec Surefire
 
 J'ai rencontré l'erreur suivante :

--- a/_posts/2012-11-16-progfun.md
+++ b/_posts/2012-11-16-progfun.md
@@ -97,7 +97,7 @@ donner des idées à ceux qui voudraient aller plus loin :
 -   [Akka](http://akka.io/), un framework d'Actor, pour faciliter l'écriture de code concurrent
 -   [Play](http://www.playframework.org/), un framework web
 -   un article de Jonas Boner sur le [Cake
-    pattern](http://jonasboner.com/2008/10/06/real-world-scala-dependency-injection-di/), pour
+    pattern](http://jonasboner.com/real-world-scala-dependency-injection-di/), pour
     implémenter l'injection de dépendances
 -   Une [video](http://www.youtube.com/watch?feature=player_embedded&v=ZasXwtTRkio) sur l'injection
     de dépendances avec une monade Reader

--- a/_posts/2012-12-05-casbah.md
+++ b/_posts/2012-12-05-casbah.md
@@ -5,7 +5,7 @@ layout: blog
 ---
 J'utilise [Casbah](https://github.com/mongodb/casbah), le driver Scala officiel pour MongoDB. Pour
 être précis, la dernière version 2.1.5.0, enfin la dernière version
-[documentée](http://api.mongodb.org/scala/casbah/)… Mon cas d'utilisation est de faire des
+documentée … Mon cas d'utilisation est de faire des
 aggregations, j'ai donc besoin de la méthode `DBCollection.aggregate`. Malheureusement, cette
 dernière est introuvable.
 

--- a/_posts/2013-03-06-play2-mini.md
+++ b/_posts/2013-03-06-play2-mini.md
@@ -50,11 +50,9 @@ excellente source d'inspiration pour ses propres développements.
 
 play2.1 n'est pas encore supporté (play 2.1-RC2 pour le moment).
 
-~ run n'est pas encore supporté, [un bug](https://github.com/typesafehub/play2-mini/issues/10) est
-ouvert.
+~ run n'est pas encore supporté, un bug est ouvert.
 
 ## Références
 
--   [play2-mini sur GitHub](https://github.com/typesafehub/play2-mini)
 -   [play2-mini dans la doc Akka](http://doc.akka.io/docs/akka/2.0.5/modules/http.html)
 

--- a/_posts/2013-03-11-backup.md
+++ b/_posts/2013-03-11-backup.md
@@ -64,7 +64,7 @@ rsync -av --delete --link-dest=$destdir/backup.1 $element $destdir/backup.0
 ```
 
 Le script complet est sur
-[GitHub](https://github.com/YannMoisan/dotfiles/blob/master/scripts/backup/)
+[GitHub](https://github.com/YannMoisan/dotfiles/blob/master/bin/backup/)
 
 Source :
 

--- a/_posts/2013-04-15-archlinux.md
+++ b/_posts/2013-04-15-archlinux.md
@@ -110,7 +110,7 @@ ne fournit pas de pilotes pour Linux, et la montre n'est pas vue comme un simple
 la connecte en USB.
 
 Voici cependant la marche à suivre pour l'utiliser. Tout d'abord, il faut blacklister le module
-gps\_garmin. Ensuite, il faut installer [garmintools](https://code.google.com/p/garmintools/) et
+gps\_garmin. Ensuite, il faut installer [garmintools](https://code.google.com/archive/p/garmintools/) et
 [garminplugin](http://www.andreas-diesner.de/garminplugin). Le premier est un ensemble d'outils en
 ligne de commande, qui implémente le protocole de communication avec la montre. Le second est un
 plugin Firefox, qui utilise le premier, afin de permettre le dialogue avec la montre depuis le

--- a/_posts/2013-04-19-vim-scala.md
+++ b/_posts/2013-04-19-vim-scala.md
@@ -28,8 +28,8 @@ aussi l'indentation et la détection des fichiers scala.
 ## Navigation dans le code source
 
 Ctags est un outil classique du monde Unix. Il ne supporte pas Scala par défaut, mais il est très
-simple d'ajouter ce support en créant/modifiant un fichier `~/.ctags`. Vous pouvez récuperer le
-fichier [ici](http://latestbuild.net/scala-ctags-and-vim-tagbar). On peut maintenant sauter à la
+simple d'ajouter ce support en créant/modifiant un fichier `~/.ctags`. ~~Vous pouvez récuperer le
+fichier ici.~~ On peut maintenant sauter à la
 définition du terme sous le curseur en tapant `<C-]>`.
 
 Alors que l'IDE recompile de manière transparente le code pour permettre la complétion, il faut
@@ -129,7 +129,5 @@ Voici les fonctionnalités qui n'ont pas d'équivalent dans vim, classées par o
 
 ## Sources
 
--   [scala-ctags-and-vim-tagbar](http://latestbuild.net/scala-ctags-and-vim-tagbar)
 -   [Documentation du plugin ctrlp.vim](http://kien.github.io/ctrlp.vim/)
--   [Documentation du plugin tagbar](http://majutsushi.github.io/tagbar/)
 

--- a/_posts/2013-07-05-conseils.md
+++ b/_posts/2013-07-05-conseils.md
@@ -48,7 +48,6 @@ Firefox, années après années.
 
 -   [97 things every programmer should
     now](http://programmer.97things.oreilly.com/wiki/index.php/Contributions_Appearing_in_the_Book)
--   [Tell, Don't Ask](http://pragprog.com/articles/tell-dont-ask)
 -   [Mocks Aren't Stubs](http://martinfowler.com/articles/mocksArentStubs.html)
 -   [Inversion of Control Containers and the Dependency Injection
     pattern](http://martinfowler.com/articles/injection.html)
@@ -61,7 +60,7 @@ Firefox, années après années.
 -   [The Pragmatic Programmer Quick Reference
     Guide](http://www.codinghorror.com/blog/2004/10/a-pragmatic-quick-reference.html)
 -   [Latency Numbers Every Programmer Should
-    Know](http://www.eecs.berkeley.edu/~rcs/research/interactive_latency.html)
+    Know](https://colin-scott.github.io/personal_website/research/interactive_latency.html)
 -   [Agile Manifesto](http://agilemanifesto.org/)
 -   [Learn REST: A Tutorial](http://rest.elkstein.org/)
 -   [HTTP](http://valtechtechno.github.io/cours-du-soir-http/#landing-slide)

--- a/_posts/2013-10-26-scalaio.md
+++ b/_posts/2013-10-26-scalaio.md
@@ -100,6 +100,6 @@ un éventuel fait qui m'a marqué
 Conclusion
 
 C'est le genre d'évènement inspirant. Je repars donc avec une liste de chose à faire bien remplie :
-Finir de lire l'excellent [Functional Programming in Scala](http://www.manning.com/bjarnason/),
+Finir de lire l'excellent [Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala),
 essayer Typesafe Activator, développer un POC avec Akka, passer du temps à étudier les librairies
 scalaz, shapeless. Certaines notions m'ont aussi échappé comme les Free Monad.

--- a/_posts/2013-12-23-weechat.md
+++ b/_posts/2013-12-23-weechat.md
@@ -28,7 +28,7 @@ Pour automatiser cela entre deux lancements
 ```
 
 La dernière ligne permet de s'identifier automatiquement. Il faut avoir au préalable engistrer son
-pseudo sur NickServ <sup>[1](#cite1)</sup>, ce que je vous conseille pour éviter qu'on usurpe votre
+pseudo sur NickServ <sup>[[1]](#cite1)</sup>, ce que je vous conseille pour éviter qu'on usurpe votre
 identité.
 
 Pour ajouter des mappings (vimesques, évidemment)
@@ -46,7 +46,7 @@ highlight. Ce beep est intercepté par mon WM pour me highlither le workspace.
 /script install beep.pl
 ```
 
-Pour fixer quelques problèmes avec le thème solarized.<sup>[3](#cite3)</sup>
+Pour fixer quelques problèmes avec le thème solarized.<sup>[[3]](#cite3)</sup>
 
 ```
 /set weechat.bar.status.color_bg 0
@@ -111,13 +111,8 @@ Pour vos backups, la configuration de bitlbee est dans `/var/lib/bitlbee`
 
 ## Liens utiles
 
-1.  
-
-    [Configurer son pseudo IRC](https://freenode.net/kb/answer/registration)
-2.  [Guide de démarrage rapide
-    WeeChat](http://www.weechat.org/files/doc/stable/weechat_quickstart.fr.html)
-3.  
-
-    [Pimping
-    solarized](https://gist.github.com/inhies/5145065/raw/7e6027766e719ab19161fd2788b5da924c29c28c/pimping.md)
-
+<p id="cite1">[1] <a href="https://freenode.net/kb/answer/registration">Configurer son pseudo IRC</a></p>
+<p id="cite2">[2] <a href="http://www.weechat.org/files/doc/stable/weechat_quickstart.fr.html">Guide de démarrage rapide
+WeeChat</a></p>
+<p id="cite3">[3] <a href="https://gist.github.com/inhies/5145065/raw/7e6027766e719ab19161fd2788b5da924c29c28c/pimping.md">Pimping
+solarized</a></p>

--- a/_posts/2013-12-23-weechat.md
+++ b/_posts/2013-12-23-weechat.md
@@ -4,7 +4,7 @@ description: Configurer weechat et bitlbee
 layout: blog
 ---
 Dans ce billet, nous allons voir comment configurer [WeeChat](http://www.weechat.org/), un client
-IRC en ncurses et [bitlbee](http://www.bitlbee.org%22), une passerelle entre IRC et les protocoles
+IRC en ncurses et [bitlbee](http://www.bitlbee.org), une passerelle entre IRC et les protocoles
 de messageries instantanées.
 
 ## Weechat
@@ -113,7 +113,7 @@ Pour vos backups, la configuration de bitlbee est dans `/var/lib/bitlbee`
 
 1.  
 
-    [Configurer son pseudo IRC](http://freenode.net/faq.shtml#nicksetup)
+    [Configurer son pseudo IRC](https://freenode.net/kb/answer/registration)
 2.  [Guide de démarrage rapide
     WeeChat](http://www.weechat.org/files/doc/stable/weechat_quickstart.fr.html)
 3.  

--- a/_posts/2014-01-09-regexp.md
+++ b/_posts/2014-01-09-regexp.md
@@ -4,8 +4,8 @@ description: Syntaxe des expressions régulières
 layout: blog
 ---
 Cet article présente les différentes syntaxes d'expressions régulières. Ce n'est pas une
-introduction ou un tutoriel, il en existe déjà de très bons sur le web <sup>[1](#cite1)</sup>, ainsi
-que des outils en ligne pour les tester <sup>[2](#cite2)</sup>. Les expressions régulières sont un
+introduction ou un tutoriel, il en existe déjà de très bons sur le web <sup>[[1]](#cite1)</sup>, ainsi
+que des outils en ligne pour les tester <sup>[[2]](#cite2)</sup>. Les expressions régulières sont un
 outil indispensable pour les développeurs et autres administrateurs système.
 
 Comme d'habitude en informatique, il existe plusieurs syntaxes pour les déclarer : BRE, ERE, PCRE et
@@ -57,10 +57,5 @@ par `ack` qui utilise la syntaxe de Perl.
 
 ## Liens utiles
 
-1.  
-
-    [regular-expression.info](http://www.regular-expressions.info/)
-2.  
-
-    [regex101](http://regex101.com/)
-
+<p id="cite1">[1] <a href="http://www.regular-expressions.info/">regular-expression.info</a></p>
+<p id="cite2">[2] <a href="http://regex101.com/">regex101.com</a></p>

--- a/_posts/2014-03-17-recommandation.md
+++ b/_posts/2014-03-17-recommandation.md
@@ -3,7 +3,7 @@ title: Système de recommandation avec Apache Mahout
 description: Retour d'expérience sur la conception d'un système de recommandation avec Apache Mahout
 layout: blog
 ---
-Sur mon dernier projet, [BlueKiwi](http://www.bluekiwi-software.com/fr/), j'ai eu la chance de
+Sur mon dernier projet, BlueKiwi, j'ai eu la chance de
 travailler sur un système de recommandation. C'est une plateforme de gestion de contenu, et donc un
 utilisateur peut lire ou noter des articles. Le but est donc de recommander des articles à un
 utilisateur, en se basant sur ses interactions passées avec la plateforme. Cela s'appelle du

--- a/_posts/2014-03-18-vim-scala-2.md
+++ b/_posts/2014-03-18-vim-scala-2.md
@@ -33,8 +33,8 @@ formateur.
 ## Navigation dans le code source
 
 Ctags est un outil classique du monde Unix. Il ne supporte pas Scala par défaut, mais il est très
-simple d'ajouter ce support en créant/modifiant un fichier `~/.ctags`. Vous pouvez récuperer le
-fichier [ici](http://latestbuild.net/scala-ctags-and-vim-tagbar). On peut maintenant sauter à la
+simple d'ajouter ce support en créant/modifiant un fichier `~/.ctags`. ~~Vous pouvez récuperer le
+fichier ici~~. On peut maintenant sauter à la
 définition du terme sous le curseur en tapant `<C-]>`.
 
 Alors que l'IDE recompile de manière transparente le code pour permettre la complétion, il faut
@@ -146,9 +146,7 @@ scalariform.
 
 ## Sources
 
--   [scala-ctags-and-vim-tagbar](http://latestbuild.net/scala-ctags-and-vim-tagbar)
 -   [Documentation du plugin ctrlp.vim](http://kien.github.io/ctrlp.vim/)
--   [Documentation du plugin tagbar](http://majutsushi.github.io/tagbar/)
 -   [Quick bug fixing in Scala with SBT and
     Vim](http://aloiscochard.blogspot.fr/2013/02/quick-bug-fixing-in-scala-with-sbt-and.html)
 

--- a/_posts/2014-03-27-ranger.md
+++ b/_posts/2014-03-27-ranger.md
@@ -51,8 +51,7 @@ Vous pouvez retrouver ma config sur github. J'ai configuré la ligne de commande
 ajouter une commande pour extraire les archives.
 
 Il est aussi possible de configurer le thème de couleur en créant un répertoire
-`~/.config/.ranger/colorschemes`. J'utilise le thème
-[solarized](https://github.com/tannhuber/themes/tree/master/ranger) :
+`~/.config/.ranger/colorschemes`. J'utilise le thème solarized.
 
 Voici les points qui ont attirés mon attention dans les dernières versions :
 

--- a/_posts/2014-03-29-debit.md
+++ b/_posts/2014-03-29-debit.md
@@ -71,9 +71,7 @@ fait possible d'écouter de la musique sur le NAS, même en Wifi.
 
 ## Liens
 
--   [Comparatif entre les connexions Ethernet, WiFi et
-    CPL](http://www.maisondunumerique.com/cest-quoi-un-reseau-domestique/comparatif-ethernet-wifi-cpl)
 -   [FreeBox Server WiFI - 40 Mhz](http://www.samn0.fr/index.php/tag/40-mhz-canal-inferieur)
 -   [Freebox Server](http://www.freebox-v6.fr/wiki/index.php?title=Freebox_Server)
--   [Test de débit K-Net](http://debit.k-net.fr/)
+-   ~~http://debit.k-net.fr~~
 

--- a/_posts/2014-05-02-hebergement.md
+++ b/_posts/2014-05-02-hebergement.md
@@ -3,7 +3,7 @@ title: Hébergement sur un serveur dédié
 description: Les étapes à suivre pour passer d'un hébergement chez un prestataire web vers un hébergement sur son serveur dédié
 layout: blog
 ---
-Jusqu'ici, ce site était hebergé chez [hebergement-gratuit](http://www.hebergement-gratuit.com/),
+Jusqu'ici, ce site était hebergé chez `www.hebergement-gratuit.com`,
 qui offre un hébergement totalement gratuit, sans publicité. Le service est de bonne qualité, mais
 limité. Tout d'abord, ce prestataire impose l'utilisation de ses serveurs DNS. Il faut donc
 configurer une délégation DNS, ce qui se fait sans problème chez [Gandi](http://www.gandi.net), mon

--- a/_posts/2014-05-29-osx.md
+++ b/_posts/2014-05-29-osx.md
@@ -12,7 +12,7 @@ transition de Linux vers OS X.
 
 La première difficulté est le clavier; les touches ⌘ Command et ⌥ Option sont inversées, et il n'y a
 qu'un seul Control, à contrario des règles d'ergonomie. Heureusement, j'utilise un clavier externe
-et ma disposition de clavier qwerty-lafayette est disponible sur OS X<sup>[1](#cite1)</sup>, merci
+et ma disposition de clavier qwerty-lafayette est disponible sur OS X<sup>[[1]](#cite1)</sup>, merci
 [kaze](https://twitter.com/fabi1cazenave) !
 
 Voici les raccourcis que j'utilise le plus :
@@ -84,20 +84,20 @@ par `[ \t]`. Ce qui se fait avec la commande suivante dans Vim : `:%s/\\s/[ \\t]
 
 ## Vim
 
-La version de Vim installée par défaut est trop vieille<sup>[2](#cite2)</sup>.
+La version de Vim installée par défaut est trop vieille<sup>[[2]](#cite2)</sup>.
 
 ```
 brew install macvim --with-cscope --with-lua --override-system-vim
 ```
 
 Le path de Vim diffère de celui du SHELL, ce qui fait que ctags ne fonctionne pas dans Vim. Voici la
-commande pour corriger cela<sup>[3](#cite3)</sup> :
+commande pour corriger cela<sup>[[3]](#cite3)</sup> :
 
 ```
 sudo chmod ugo-x /usr/libexec/path_helper
 ```
 
-Par défaut, ma configuration du clipboard ne fonctionnait pas<sup>[4](#cite4)</sup>. J'ai remplacé :
+Par défaut, ma configuration du clipboard ne fonctionnait pas<sup>[[4]](#cite4)</sup>. J'ai remplacé :
 
 ```
 set clipboard=unnamedplus
@@ -124,16 +124,7 @@ sont très pratiques (par ex. [Dash](http://kapeli.com/dash) pour centraliser le
 
 ## Liens
 
-1.  
-
-    <http://fabi1cazenave.github.io/qwerty-lafayette/>
-2.  
-
-    <https://github.com/dotphiles/dotzsh#mac-os-x>
-3.  
-
-    <http://www.codeography.com/2013/06/11/install-macvim-with-lua-support.html>
-4.  
-
-    <http://vim.wikia.com/wiki/Mac_OS_X_clipboard_sharing>
-
+<p id="cite1">[1] <a href="http://fabi1cazenave.github.io/qwerty-lafayette/">http://fabi1cazenave.github.io/qwerty-lafayette/</a></p>
+<p id="cite2">[2] <a href="https://github.com/dotphiles/dotzsh#mac-os-x">https://github.com/dotphiles/dotzsh#mac-os-x</a></p>
+<p id="cite3">[3] <a href="http://www.codeography.com/2013/06/11/install-macvim-with-lua-support.html">http://www.codeography.com/2013/06/11/install-macvim-with-lua-support.html</a></p>
+<p id="cite4">[4] <a href="http://vim.wikia.com/wiki/Mac_OS_X_clipboard_sharing">http://vim.wikia.com/wiki/Mac_OS_X_clipboard_sharing</a></p>

--- a/_posts/2015-03-07-tuples.md
+++ b/_posts/2015-03-07-tuples.md
@@ -14,7 +14,7 @@ def flatMapValues[A, B, C](s:Seq[(A, B)])(f: B => Seq[C]) : Seq[(A, C)] =
 
 Le code client est alors `flatMapValues(Seq("a"->1, "b"->2))(Seq.fill(_)("x"))`. Afin d'avoir un
 code client *fluent*, on peut introduire une [*implicit
-class*](http://docs.scala-lang.org/sips/completed/implicit-classes.html), qui permet de fournir des
+class*](https://docs.scala-lang.org/sips/implicit-classes.html), qui permet de fournir des
 méthodes d'extension à un type existant, une séquence de tuples ici.
 
 ```

--- a/_posts/2015-07-25-docker.md
+++ b/_posts/2015-07-25-docker.md
@@ -109,7 +109,7 @@ for site1 to the `/etc/hosts` of the proxy container.
 
 Command lines are now very long and it becomes painfull to run the whole things. Hopefully, there is
 a tool in the fast-growing Docker ecosystem that will help us :
-[docker-compose](https://www.docker.com/docker-compose).
+[docker-compose](https://docs.docker.com/compose/).
 
 We just have to define our multi-container application with a configuration file in YAML to describe
 how to run our 3 containers

--- a/_posts/2015-10-21-continuous-integration.md
+++ b/_posts/2015-10-21-continuous-integration.md
@@ -282,7 +282,6 @@ If you don't know SauceLabs, it's a cloud solution to test a web app on a lot of
 Sauce Labs provides an integration with Travis CI, and Travis CI provide an integration with Sauce
 Labs.
 
--   [Sauce Labs doc](https://docs.saucelabs.com/ci-integrations/travis-ci/)
 -   [Travis doc](http://docs.travis-ci.com/user/sauce-connect/)
 
 The main point is to configure sauce-connect, a tunnel to secure communication between Travis CI ans
@@ -415,9 +414,7 @@ Now it's configured, you want to display the information on your `README` page. 
 snippet as explained in the Sauce Labs documentation and … the status is unknown !
 
 PlayFramework doesn't provide built-in support for Sauce Labs, you have to update the status of each
-test manually by using the
-[REST API](https://docs.saucelabs.com/reference/test-configuration/#job-annotation-with-the-rest-api)
-provided by Sauce Labs.
+test manually by using the REST API provided by Sauce Labs.
 
 ## Conclusion
 

--- a/_posts/2016-03-29-play-swagger.md
+++ b/_posts/2016-03-29-play-swagger.md
@@ -146,10 +146,8 @@ deals with this header.
   )
 ```
 
-Finally, I still have two questions :
+Finally, I still have one question :
 
--   [How do you model an empty
-    body](http://stackoverflow.com/questions/36306341/how-do-you-model-an-empty-body-with-swagger-annotation)
 -   [Why swagger-ui doesn't display the response model for an alternate
     response](http://stackoverflow.com/questions/36304732/swagger-ui-doesnt-display-the-response-model-for-a-400)
 

--- a/_posts/2020-04-11-donnees.md
+++ b/_posts/2020-04-11-donnees.md
@@ -58,4 +58,4 @@ documents importants reçus par mail devraient être sauvegardés dans vos docum
 
 Voici un schéma qui récapitule les différents transferts de données.
 
-![](/assets/digital-life.png)
+![digital life](/assets/digital-life.png)

--- a/cv.html
+++ b/cv.html
@@ -16,7 +16,7 @@ layout: blog
     <li>Je <b>développe</b> en <b>Scala</b> (Play, Akka) depuis 1 an et en <b>Java</b> (Spring, Hibernate, Web Services, XML, …) depuis 13 ans, sous <b>Linux</b></li>
     <li>Je suis un <i><b>software craftsmanship</b></i> (code propre, TDD, Intégration continue)</li>
     <li>Je privilégie la <b>simplicité</b> (donc REST plutôt que SOAP, Git plutôt que Clearcase, Netty plutôt que WebSphere)
-    <li>J'apprends continuellement, notamment en assistant aux soirées des <b>groupes d'utilisateurs</b> (sur <a href="http://www.parisjug.org">Java</a>, <a href="https://groups.google.com/forum/?fromgroups#!forum/paris-scala-user-group">Scala</a>, Hadoop, …) et en suivant des <b>cours en ligne</b> (<a href="https://www.coursera.org/course/progfun">Scala</a>, <a href="https://education.10gen.com/courses/10gen/M101J/2013_Spring/about">MongoDB</a>)
+    <li>J'apprends continuellement, notamment en assistant aux soirées des <b>groupes d'utilisateurs</b> (sur <a href="http://www.parisjug.org">Java</a>, <a href="https://groups.google.com/forum/?fromgroups#!forum/paris-scala-user-group">Scala</a>, Hadoop, …) et en suivant des <b>cours en ligne</b> (<a href="https://www.coursera.org/course/progfun">Scala</a>, MongoDB M101J)
     <li>Je progresse continuellement, en participant à des <a href="soiree-software-cratfsmanship.html">kata</a> et à des <a href="http://www.codingame.com/cg/?target=language&id=2#!ranking:10:yamo">dojo</a>.</li>
     <li>J'optimise les <b>performances</b> et écrit régulièrement du code concurrent voire distribué</li>
     <li>J'aime l'<b>open source</b>. Je relève des bugs <a href="https://jira.springsource.org/browse/BATCH-1778">BATCH-1778</a>, <a href="https://issues.apache.org/jira/browse/MAHOUT-1068">MAHOUT-1068</a> et propose des corrections <a href="https://github.com/mongodb/casbah/pull/59">Casbah 59</a>, <a href="https://issues.apache.org/jira/browse/MAHOUT-1044">MAHOUT-1044</a>.</li>
@@ -31,7 +31,7 @@ layout: blog
 <dl>
     <dt>05/2012 - aujourd'hui</dt>
     <dd>
-        <h4><a href="http://www.bluekiwi-software.com/fr/">Bluekiwi</a>, réseau social d'entreprise en mode SaaS</h4>
+        <h4>Bluekiwi, réseau social d'entreprise en mode SaaS</h4>
         <h5>Architecte</h5>
         <ul>
             <li><b>recommandation sociale</b> basée sur <b>Mahout</b></li>
@@ -70,7 +70,7 @@ layout: blog
         <h5>Développeur</h5>
         <ul>
             <li>évolution en architecture J2EE d'une application de gestion des OST (Opérations sur Titre) pour BNP Arbitrage, projet Picasso</li>
-            <li>moteur de portail de gestion de contenu <b>Open Source</b> pour la Mairie de Paris, projet <a href="http://fr.lutece.paris.fr">Lutèce</a></li>
+            <li>moteur de portail de gestion de contenu <b>Open Source</b> pour la Mairie de Paris, projet <a href="https://lutece.paris.fr">Lutèce</a></li>
             <li>refonte du poste de travail en agences pour le Crédit du Nord, projet Chopin</li>
         </ul>
 
@@ -88,7 +88,7 @@ layout: blog
 <dl>
     <dl>
         <dt>2011</dt>
-        <dd><a href="http://www.zenika.com/formation-java-specialiste.html">Java Spécialiste</a></dd>
+        <dd>Java Spécialiste</dd>
     </dl>
     <dt>2011</dt>
     <dd>Scrum Master certifié</dd>


### PR DESCRIPTION
Broken links are detected with  
```
htmlproofer --assume-extension ./_site
```

If we have a look at broken links, there are some interesting findings :
- some domain names have disappeared (e.g. www.hebergement-gratuit.com)
- popular projects reached their end of life: casbah, play2-mini
- guava is now hosted on github
- even an excellent developer like jonas boner might change its URLs without putting in place a redirect

This PR also fix internal links that were broken during the markdown migration